### PR TITLE
Guzzle won't throw exceptions for HTTP codes 4xx and 5xx.

### DIFF
--- a/src/Postmark/Transport.php
+++ b/src/Postmark/Transport.php
@@ -57,6 +57,7 @@ class Transport implements Swift_Transport {
 	 */
 	public function send(Swift_Mime_Message $message, &$failedRecipients = null) {
 		$client = $this->getHttpClient();
+		$client->setDefaultOption('exceptions', false);
 
 		$v = $this->version;
 		$o = $this->os;


### PR DESCRIPTION
I was getting back the HTTP error 422: Unprocessable Entity, but the exception was preventing me from seeing the JSON response from Postmark with the specific API error code. Maybe this can be expanded upon so that an exception is thrown after the $response->json() is available from Guzzle.
