### PR TITLE
fixes issue if only setting CC or BCC as email

### DIFF
--- a/src/Postmark/Transport.php
+++ b/src/Postmark/Transport.php
@@ -183,7 +183,9 @@ class Transport implements Swift_Transport {
 	 */
 	private function processRecipients(&$payload, $message) {
 		$payload['From'] = join(',', $this->convertEmailsArray($message->getFrom()));
-		$payload['To'] = join(',', $this->convertEmailsArray($message->getTo()));
+		if ($to = $message->getTo()) {
+            $payload['To'] = join(',', $this->convertEmailsArray($to));
+        }
 		$payload['Subject'] = $message->getSubject();
 
 		if ($cc = $message->getCc()) {


### PR DESCRIPTION
Addresses issue #17 

Things to verify before accepting the PR:

- [x] Can Postmark API send out with just BCC or CC? Or does it require TO?
- [x] Does Swiftmailer care that the transport does not have the TO field set?

If the above items do require TO then throwing an exception is probably preference.