### PR TITLE
Be able to throw exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,15 @@ $mailer->send($message);
 
 ?>
 ```
+
+##### 3. Throw exceptions on Postmark api errors
+
+```php
+$transport = new \Postmark\Transport('<SERVER_TOKEN>');
+$transport->registerPlugin(new \Postmark\ThrowExceptionOnFailurePlugin());
+
+$message = new Swift_Message('Hello from Postmark!');
+$mailer->send($message); // Exception is throw when response !== 200
+
+?>
+```

--- a/src/Postmark/ThrowExceptionOnFailurePlugin.php
+++ b/src/Postmark/ThrowExceptionOnFailurePlugin.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Postmark;
+
+class ThrowExceptionOnFailurePlugin implements \Swift_Events_ResponseListener
+{
+    public function responseReceived(\Swift_Events_ResponseEvent $event)
+    {
+        if (!$event->isValid()) {
+            throw new \Swift_TransportException($event->getResponse());
+        }
+    }
+}

--- a/tests/ThrowExceptionOnFailurePluginTest.php
+++ b/tests/ThrowExceptionOnFailurePluginTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Postmark\ThrowExceptionOnFailurePlugin;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+class ThrowExceptionOnFailurePluginTest extends TestCase {
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testValidResponseThrowsNoException()
+    {
+        $valid = true;
+        $event = new \Swift_Events_ResponseEvent(new \Postmark\Transport('SERVER_TOKEN'), 'success', $valid);
+
+        $plugin = new ThrowExceptionOnFailurePlugin();
+        $plugin->responseReceived($event); // no exception
+    }
+
+    public function testInvalidResponseThrowsException()
+    {
+        $valid = false;
+        $event = new \Swift_Events_ResponseEvent(new \Postmark\Transport('SERVER_TOKEN'), 'invalid response', $valid);
+
+        $plugin = new ThrowExceptionOnFailurePlugin();
+
+        $this->expectException(\Swift_TransportException::class);
+        $this->expectExceptionMessage('invalid response');
+
+        $plugin->responseReceived($event);
+    }
+}

--- a/tests/TransportTest.php
+++ b/tests/TransportTest.php
@@ -146,8 +146,19 @@ class MailPostmarkTransportTest extends TestCase {
 
     public function testServerTokenReturnedFromPublicMethod()
     {
-        $transport = new PostmarkTransportStub([new Response(200)]);
+        $transport = new PostmarkTransportStub();
         $this->assertEquals($transport->getServerToken(), 'TESTING_SERVER');
+    }
+
+    public function testFailedResponse()
+    {
+        $message = new Swift_Message();
+
+        $transport = new PostmarkTransportStub([new Response(401)]);
+        $transport->registerPlugin(new \Postmark\ThrowExceptionOnFailurePlugin());
+
+        $this->expectException(\Swift_TransportException::class);
+        $transport->send($message);
     }
 }
 


### PR DESCRIPTION
Add responseReceived event which is triggered directly after the
performed call.

Add ThrowExceptionOnFailurePlugin which listens to the responseReceived
event and throws an exception on failures.

This fixes #15 