### PR TITLE
[BUG] Fix response not being sent to the responseReceived plugin method

### DIFF
--- a/src/Postmark/Transport.php
+++ b/src/Postmark/Transport.php
@@ -95,8 +95,8 @@ class Transport implements Swift_Transport {
 		]);
 
 		$success = $response->getStatusCode() === 200;
-
-		if ($responseEvent = $this->_eventDispatcher->createResponseEvent($this, $response->getBody()->getContents(), $success)) {
+		
+		if ($responseEvent = $this->_eventDispatcher->createResponseEvent($this, (string) $response->getBody(), $success)) {
 			$this->_eventDispatcher->dispatchEvent($responseEvent, 'responseReceived');
 		}
 
@@ -104,7 +104,7 @@ class Transport implements Swift_Transport {
 			$sendEvent->setResult($success ? \Swift_Events_SendEvent::RESULT_SUCCESS : \Swift_Events_SendEvent::RESULT_FAILED);
 			$this->_eventDispatcher->dispatchEvent($sendEvent, 'sendPerformed');
 		}
-		
+
 		return $success
 			? $this->getRecipientCount($message)
 			: 0;


### PR DESCRIPTION
The method `getContents()` is, somehow, not returning the body, instead it's returning an empty string `""`.

The source of the problem is possibly inside PSR7's Stream class, responsible for this call:

```
$contents = stream_get_contents($this->stream);
```

Which returns the empty string.

But when forcing a string cast on the stream:

```
(string) $response->getBody()
```

That call is almost the same, expect for the rewind:

```
$this->seek(0);
return (string) stream_get_contents($this->stream);`
```

So we had two options here:

1) Force a rewind before reading that stream.
2) Or just force a call to `__toString()`, which works fine.