### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-vendor
-build
-.phpintel
+/build
 /composer.lock
+/vendor


### PR DESCRIPTION
## Summary
- vendor and build files are only relevant from the root path `/`, so no need
  to configure gitignore to ignore wherever they occur
- remove `.phpintel`
  Editor/IDE specific ignores should be on each developers machine, otherwise
  every project eventually ends up with multitude if gitignores for every
  combination out there

Lastly, sorted alphabetically 😎