### PR TITLE
Allow Guzzle 7 too

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "description": "A Swiftmailer Transport for Postmark.",
     "require": {
         "swiftmailer/swiftmailer": "^6.0.0",
-        "guzzlehttp/guzzle": "^6.0.0"
+        "guzzlehttp/guzzle": "^6.0|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0.0"


### PR DESCRIPTION
Works without code change, it's literally only used in one place in `\Postmark\Transport::send`