### PR TITLE
Fix: Do not install dependencies from source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ php:
 
 before_script:
   - composer self-update
-  - composer update --no-interaction --prefer-source --dev
+  - composer update --no-interaction --dev
 
 script: composer test


### PR DESCRIPTION
This PR

* [x] stops installing dependencies from source

💁‍♂️ It's slower, and the dependencies cannot be cached.

❗ I have not made this change in #42, because it's out of scope.