### PR TITLE
Adding Postmark Message ID in response headers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,20 @@ $message = new Swift_Message('Hello from Postmark!');
 $message->getHeaders()->addTextHeader('X-PM-Message-Stream', 'another-stream');
 ```
 
+##### 6. Getting the Postmark Message ID after sending
+After sending the mail to Postmark, it is possible to get the Postmark ID.
+
+```php 
+$transport = new \Postmark\Transport('<SERVER_TOKEN>', $defaultHeaders);
+$mailer = new Swift_Mailer($transport);
+
+$message = new Swift_Message('Hello from Postmark!');
+
+$mailer->send($message);
+
+$postmarkID = $message->getHeaders()->get('X-PM-Message-Id')->getValue();
+```
+
 ##### Notes:
 
 - The Transport uses the [Postmark API](https://postmarkapp.com/developer) internally to send mail, via the [/email endpoint](https://postmarkapp.com/developer/api/email-api#send-a-single-email). Other sending features such as Batch sending or sending via Templates are currently not supported by this library.

--- a/src/Postmark/Transport.php
+++ b/src/Postmark/Transport.php
@@ -108,11 +108,11 @@ class Transport implements Swift_Transport {
 			$this->_eventDispatcher->dispatchEvent($responseEvent, 'responseReceived');
 		}
 
-        // Get the Postmark message ID
-        $jsonResponse = json_decode($response->getBody()->__toString(), true);
-        if (isset($jsonResponse['MessageID'])) {
-            $message->getHeaders()->addTextHeader('X-PM-Message-Id', $jsonResponse['MessageID']);
-        }
+		// Get the Postmark message ID
+		$jsonResponse = json_decode($response->getBody()->__toString(), true);
+		if (isset($jsonResponse['MessageID'])) {
+		    $message->getHeaders()->addTextHeader('X-PM-Message-Id', $jsonResponse['MessageID']);
+		}
 
 		if ($sendEvent) {
 			$sendEvent->setResult($success ? \Swift_Events_SendEvent::RESULT_SUCCESS : \Swift_Events_SendEvent::RESULT_FAILED);

--- a/src/Postmark/Transport.php
+++ b/src/Postmark/Transport.php
@@ -108,6 +108,12 @@ class Transport implements Swift_Transport {
 			$this->_eventDispatcher->dispatchEvent($responseEvent, 'responseReceived');
 		}
 
+        // Get the Postmark message ID
+        $jsonResponse = json_decode($response->getBody()->__toString(), true);
+        if (isset($jsonResponse['MessageID'])) {
+            $message->getHeaders()->addTextHeader('X-PM-Message-Id', $jsonResponse['MessageID']);
+        }
+
 		if ($sendEvent) {
 			$sendEvent->setResult($success ? \Swift_Events_SendEvent::RESULT_SUCCESS : \Swift_Events_SendEvent::RESULT_FAILED);
 			$this->_eventDispatcher->dispatchEvent($sendEvent, 'sendPerformed');


### PR DESCRIPTION
As requested in issue #24, with this PR it is possible to get the Postmark Message ID after sending the message.